### PR TITLE
Allow results space to expand rather than scrolling

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -46,6 +46,7 @@ DB Access Plugin Changelog
 <p><b>1.2.3</b> -- (to be determined)</p>
 <ul>
     <li>[<a href='https://github.com/igniterealtime/openfire-dbaccess-plugin/issues/7'>Issue #7</a>] - Prevent issues with attempting to render BLOB data.</li>
+    <li>[<a href='https://github.com/igniterealtime/openfire-dbaccess-plugin/issues/10'>Issue #10</a>] - Insufficient space to see results</li>
 </ul>
 
 <p><b>1.2.2</b> -- February 12, 2019</p>

--- a/src/web/db-access.jsp
+++ b/src/web/db-access.jsp
@@ -37,7 +37,7 @@
 
 <div>
     <h3>SQL Output:</h3>
-    <div style="width: 100%; height: 200px; border: 1.0px solid #000000; overflow: scroll" id="output">
+    <div style="width: 100%; min-height: 200px; border: 1.0px solid #000000" id="output">
 <%
     // Handle an execution
     final List<Integer> bigDataTypes = Arrays.asList(Types.BLOB, Types.LONGVARBINARY);


### PR DESCRIPTION
When quite a few rows of results, it'd be handy for the results pane to expand to fit the results rather than be a scrollable panel.

Before:
![image](https://user-images.githubusercontent.com/2117083/102398990-e8221b80-3fd7-11eb-9e81-46eefdad1a04.png)

After:
![image](https://user-images.githubusercontent.com/2117083/102399059-0425bd00-3fd8-11eb-8b2e-ca1a2817c8c8.png)
