### PR TITLE
fixes #13: Show recently executed queries.

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -43,8 +43,9 @@
 <h1>
 DB Access Plugin Changelog
 </h1>
-<p><b>1.2.4</b> -- (To be determined)</p>
+<p><b>1.3.0</b> -- (To be determined)</p>
 <ul>
+    <li>[<a href='https://github.com/igniterealtime/openfire-dbaccess-plugin/issues/13'>Issue #13</a>] - Show recently executed queries.</li>
 </ul>
 
 <p><b>1.2.3</b> -- December 17, 2020</p>

--- a/plugin.xml
+++ b/plugin.xml
@@ -6,7 +6,7 @@
     <description>Provides administrators with a simple direct access interface to their Openfire DB.</description>
     <author>Daniel Henninger</author>
     <version>${project.version}</version>
-    <date>12/17/2020</date>
+    <date>2024-03-15</date>
     <minServerVersion>4.0.0</minServerVersion>
 
     <adminconsole>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>dbaccess</artifactId>
-    <version>1.2.4-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
     <name>DB Access Plugin</name>
     <description>Provides administrators with a simple direct access interface to their Openfire DB.</description>
 

--- a/src/web/db-access.jsp
+++ b/src/web/db-access.jsp
@@ -4,13 +4,25 @@
 <%@ page import="org.jivesoftware.util.StringUtils" %>
 <%@ page import="java.util.Arrays" %>
 <%@ page import="java.util.List" %>
+<%@ page import="java.util.LinkedList" %>
+<%@ page import="java.util.Queue" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
-
+<%!
+    static final Queue<String> PREVIOUS_QUERIES = new LinkedList<>();
+%>
 <%
     // Get parameters
     boolean execute = request.getParameter("execute") != null;
     String sql = request.getParameter("sql");
+
+    if (sql != null && !PREVIOUS_QUERIES.contains(sql)) {
+        PREVIOUS_QUERIES.add(sql);
+
+        while (PREVIOUS_QUERIES.size() > 5) {
+            PREVIOUS_QUERIES.remove();
+        }
+    }
 %>
 
 <html>
@@ -22,14 +34,21 @@
 
 <div class="information">
     Do <b>NOT</b> use this to edit your database unless you know what you are doing.  Openfire will not necessarily
-    handle changes to it's database out from under it while it is running.  Most likely you were asked to try a
+    handle changes to its database out from under it while it is running.  Most likely you were asked to try a
     couple of commands by whoever recommended this plugin, so please try to stick to that (or read-only activities).
 </div>
 
 <div>
     <h3>SQL Statement:</h3>
     <form action="db-access.jsp" method="post">
-        <textarea rows="10" cols="80" name="sql"><%= sql != null ? sql : "" %></textarea>
+        <div style="display: grid; grid-template-columns: 1fr 1fr;">
+            <div><textarea rows="10" cols="80" id="sql" name="sql"><%= sql != null ? sql : "" %></textarea></div>
+            <div>
+                <% for (final String previousQuery : PREVIOUS_QUERIES) { %>
+                <p style="font-family: monospace;"><a href="#" onclick="document.getElementById('sql').value = this.text"><%=previousQuery%></a></p>
+                <% } %>
+            </div>
+        </div>
         <br />
         <input type="submit" name="execute" value="Execute SQL"/>
     </form>


### PR DESCRIPTION
This adds a list of SQL queries that were recently executed. Clicking on a query makes move to the text input area.

The current implementation will cause the list to be cleared upon restarting Openfire or the plugin.